### PR TITLE
ayrozjlc/yii2-blockui v0.1 requires bower-asset/blockui dev-master ->…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "bower-asset/blockui": "*",
+    "bower-asset/blockui": "^2.70",
     "yiisoft/yii2": "2.0.*"
   },
   "extra": {


### PR DESCRIPTION
… found bower-asset/blockui[dev-master] but it does not match your minimum-stability.

ayrozjlc/yii2-blockui v0.1 requires bower-asset/blockui dev-master -> found bower-asset/blockui[dev-master] but it does not match your minimum-stability.